### PR TITLE
Modifying timeout

### DIFF
--- a/code/steps/sanitize_urls/readme.md
+++ b/code/steps/sanitize_urls/readme.md
@@ -27,7 +27,7 @@ The task is to extract URLs in a given string and to log whether each URL is val
 - Libraries:
     - re
     - requests
-    - urlparse
+    - urllib.parse
     - concurrent.futures
 
 

--- a/code/steps/sanitize_urls/sanitize_urls.py
+++ b/code/steps/sanitize_urls/sanitize_urls.py
@@ -7,7 +7,7 @@ import re # Regex used to identify valid URL patterns
 from url_regex import url_regex # used to identify valid URL strings
 
 num_threads_default = 100 # number of threads to run sanitize URLs in parallel
-requests_head_timeout_default = 2 # allowing 2 seconds for requests.head() to validate if a given URL exists
+requests_head_timeout_default = 1 # allowing 1 seconds for requests.head() to validate if a given URL exists
 
 def sanitize_urls_parallel(strings, num_threads = num_threads_default, timeout = requests_head_timeout_default):
     """Runs sanitize_urls() on each string in a given list in a parallelized procedure


### PR DESCRIPTION
Added an argument to specify the how long it should take for requests.head() to timeout on a bad URL (with a default value of 1 second).

NOTE: bad URLs will generally take **4 times** the specified timeout parameter, since requests.head() will be called on both the full URL and the root URL (and it seems to perform 2 attempts on each URL). 
e.g. if timeout = 1 second, then a bad URL would take up to 4 seconds to completely timeout

Also added some comments and renamed certain methods and JSON keys in the output.